### PR TITLE
Enhance Toros consensus engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ The engine enables richer, more robust LLM evaluation by orchestrating logical "
 
 ## Features
 
+- Async multi-round debate engine
+- Majority and confidence-weighted voting
+- Pluggable backend system (Ollama, Llama.cpp, OpenAI, Anthropic, etc.)
+- Rich CLI with colorized output and progress bars
+- Optional FastAPI web API
 
 ---
 
@@ -25,7 +30,7 @@ The engine enables richer, more robust LLM evaluation by orchestrating logical "
 ### 1. Install Requirements
 
 ```bash
-pip install fastapi uvicorn htmx-tailwind aiohttp sse-starlette openai anthropic llama-cpp-python pyfiglet rich
+pip install -r requirements.txt
 ```
 To use Ollama-served models, install [Ollama](https://ollama.com/) and make sure `ollama` daemon is running locally.
 
@@ -63,7 +68,7 @@ By default, the CLI will use all of: `Ollama (gemma)`, `Ollama (llama3-abliterat
 ```bash
 python consensus_agent.py --web
 ```
-Browse to [http://localhost:8000](http://localhost:8000).
+Browse to [http://localhost:8000](http://localhost:8000). Use `POST /api/ask` to query the engine programmatically.
 
 ---
 

--- a/consensus_agent.py
+++ b/consensus_agent.py
@@ -485,7 +485,6 @@ async def _ask(engine: ConsensusEngine, q: str, mode: str = "transparent"):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Yukon Systems TOROS Consensus LLM")
-    parser = argparse.ArgumentParser(description="Yukon Systems TOROS Consensus LLM")
     parser.add_argument("-q", "--query", help="Prompt to ask via CLI")
     parser.add_argument("--web", action="store_true", help="Start web server instead of CLI")
     parser.add_argument("--port", type=int, default=int(os.getenv("PORT", 8000)))

--- a/consensus_web.py
+++ b/consensus_web.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from consensus_agent import ConsensusEngine
+
+
+def make_app(engine: 'ConsensusEngine') -> FastAPI:
+    app = FastAPI(title="Toros Consensus API")
+
+    class Question(BaseModel):
+        query: str
+        rounds: int = 3
+
+    @app.post("/api/ask")
+    async def ask(question: Question):
+        return await engine.query(question.query, use_debate=True, rounds=question.rounds)
+
+    @app.get("/")
+    async def root():
+        return {"message": "Toros consensus API"}
+
+    return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+htmx-tailwind
+aiohttp
+sse-starlette
+openai
+anthropic
+llama-cpp-python
+pyfiglet
+rich

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,42 @@
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from consensus_debate import majority_vote, confidence_weighted_vote, DebateManager
+from consensus_backends import LLMBackend
+
+class FixedBackend(LLMBackend):
+    def __init__(self, name, answer, confidence=0.0):
+        super().__init__(name)
+        self._answer = answer
+        self._conf = confidence
+
+    async def complete(self, prompt: str):
+        return {"answer": self._answer, "reasoning": "", "confidence": self._conf}
+
+def test_majority_vote():
+    res = [{"answer": "A"}, {"answer": "B"}, {"answer": "B"}]
+    assert majority_vote(res) == "B"
+
+def test_confidence_weighted_vote():
+    res = [
+        {"answer": "yes", "confidence": 0.6},
+        {"answer": "no", "confidence": 0.9},
+        {"answer": "yes", "confidence": 0.6},
+    ]
+    assert confidence_weighted_vote(res) == "no"
+
+def test_debate_manager():
+    backends = [
+        FixedBackend("a", "yes", 0.6),
+        FixedBackend("b", "no", 0.9),
+        FixedBackend("c", "yes", 0.6),
+    ]
+    mgr = DebateManager(backends, rounds=1)
+    out = asyncio.run(mgr.debate("Q"))
+    assert out["winner_majority"] == "yes"
+    assert out["winner_weighted"] == "no"


### PR DESCRIPTION
## Summary
- fix argparse duplication
- add FastAPI `consensus_web` with `/api/ask`
- provide test suite and requirements
- document features and API usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7302b5ac8332b4a4f5f8f9b41d27